### PR TITLE
Unit test command improvements

### DIFF
--- a/commands/test.lua
+++ b/commands/test.lua
@@ -2,8 +2,13 @@ require 'unittest/unittest'
 
 local dir = filesystem.getCWD()
 
+if type(args) == 'table' and args[1] == '--help' then
+    return UnitTest(args)
+end
+
+
 -- Set CWD from argument 1, and correct for relative 'scripts' dir if needed
-if (type(args) == "table" and args[1] ~= nil) then
+if (type(args) == 'table' and args[1] ~= nil) then
     dir = args[1];
     if (not filesystem.directoryExists(dir)) then
         dir = "scripts/" .. dir

--- a/lib/unittest/assert.lua
+++ b/lib/unittest/assert.lua
@@ -16,7 +16,7 @@ function Assert:expectError(closure, msg)
 
     -- We expect that it did NOT succeed. So if it did, we error.
     if success then
-        error(msg or ASSERTION_FAILED_MESSAGE, 2)
+        error(msg or self:getFailMessage(), 2)
     end
 end
 
@@ -30,7 +30,7 @@ function Assert:same(left, right, msg)
         if type(right) == 'string' then
             right = '"' .. right .. '"'
         end
-        error(msg or sprintf('assertion failed: (%s) %s != (%s) %s', type(left), left, type(right), right), 2)
+        error(msg or sprintf('(%s) %s != (%s) %s. %s', type(left), left, type(right), right, self:getFailMessage()), 2)
     end
 end
 
@@ -52,7 +52,7 @@ function Assert:different(left, right, msg)
         right = '"' .. right .. '"'
     end
 
-    error(msg or sprintf('assertion failed: (%s) %s == (%s) %s', type(left), left, type(right), right), 2)
+    error(msg or sprintf('(%s) %s == (%s) %s. %s', type(left), left, type(right), right, self:getFailMessage()), 2)
 end
 
 function Assert:contains(haystack, needle, msg)
@@ -63,7 +63,7 @@ function Assert:contains(haystack, needle, msg)
     end
 
     if (not table.find(haystack, needle)) then
-        error(msg or 'assertion failed: value not found in table', 2)
+        error(msg or 'value not found in table. ' .. self:getFailMessage(), 2)
     end
 end
 
@@ -75,6 +75,6 @@ function Assert:notContains(haystack, needle, msg)
     end
 
     if (table.find(haystack, needle)) then
-        error(msg or 'assertion failed: value is contained in table but not expected', 2)
+        error(msg or 'value is contained in table but not expected. ' .. self:getFailMessage(), 2)
     end
 end

--- a/lib/unittest/unittest.lua
+++ b/lib/unittest/unittest.lua
@@ -3,6 +3,7 @@ require 'unittest/assert'
 
 UnitTest = class.new()
 function UnitTest:constructor(args)
+    args = args or {}
     self.root = filesystem.getCWD()
     self.testDirectory = "tests";
     self.output = ConsoleOutput()
@@ -17,22 +18,26 @@ function UnitTest:constructor(args)
 end
 
 function UnitTest:showHelp()
-    local helps = {
-        ['--help'] = "You're looking at it",
-        ['--verbose'] = "Provide more detailed output when available.",
-        ['--filter-files={filters}'] = "Filter files in the `tests` directory. Should be comma-separted Lua patterns." ..
-            sprintf("\n%33s%s", "",
-                "Ex: " .. self.output:sstyle('success', "test my-project --filter-files=test_.*  ") ..
-                    self.output:sstyle('petty', "Only use files beginning with `test_`"))
-    }
-    self.output:writeln('Example:\t' .. self.output:sstyle('success', 'test my-project'))
-    self.output:writeln('\nOptions:')
-    for i, v in pairs(helps) do
-        local padding = string.rep(' ', 30 - string.len(i))
-        self.output:writeln(sprintf("   %s%s%s", self.output:sstyle('success', i), padding, v))
-    end
+    local padSize = 25
+    local helpStr = [[
+Run unit tests for a MicroMacro project.
+See docs at: https://solarstrike.net/docs/micromacro/unit-test-library
 
-    self.output:writeln('')
+Example: ]] .. self.output:sstyle('success', 'test my-project') .. [[
+
+
+Options:
+  ]] .. self.output:sstyle('success', sprintf("%-" .. padSize .. "s", '--help')) .. [[ You're looking at it.
+  ]] .. self.output:sstyle('success', sprintf("%-" .. padSize .. "s", '--verbose')) ..
+                        [[ Provide more detailed output when available.
+  ]] .. self.output:sstyle('success', sprintf("%-" .. padSize .. "s", '--filter-files={filter}')) ..
+                        [[ Filter files in the `tests` directory. Should be comma-separted Lua patterns.
+  ]] .. sprintf("%-" .. padSize .. "s", '') .. self.output:sstyle('petty', '   Ex:  ') ..
+                        self.output:sstyle('success', "test my-project --filter-files=test_.*  ") ..
+                        self.output:sstyle('petty', "Only test files beginning with `test_`")
+
+    self.output:writeln(helpStr .. "\n")
+    return
 end
 
 function UnitTest:handleArgs(args)

--- a/lib/unittest/unittest.lua
+++ b/lib/unittest/unittest.lua
@@ -1,6 +1,11 @@
 require 'console/output'
 require 'unittest/assert'
 
+local function isAssertionFail(msg)
+    -- If the error message is the standard assert fail message, it must be an assertion fail
+    return string.sub(msg, -(string.len(Assert.getFailMessage()))) == Assert.getFailMessage()
+end
+
 UnitTest = class.new()
 function UnitTest:constructor(args)
     args = args or {}
@@ -189,11 +194,7 @@ function UnitTest:runTestsInFile(root, relativeFilePath)
             local errorHandler = function(err)
                 errMsg = err
 
-                -- If the error message is the standard assert fail message, it must be an assertion fail
-                local isAssertionFail = string.sub(err, -(string.len(Assert.getFailMessage()))) ==
-                                            Assert.getFailMessage()
-
-                if (not isAssertionFail) then
+                if (not isAssertionFail(err)) then
                     traceback = debug.traceback(nil, 2)
                 elseif self.showAssertionTraceback then
                     -- Have to move further up the stack to account for our wrapped assert call
@@ -203,7 +204,7 @@ function UnitTest:runTestsInFile(root, relativeFilePath)
 
             local asserter = Assert(self)
             local origAssertCount = self:getAssertCount()
-            local testname<const> = sprintf("%s::%s", self.testDirectory .. '/' .. relativeFilePath, functionName)
+            local testname<const> = sprintf("%s::%s", relativeFilePath, functionName)
             local origStdout = io.stdout
             local startTime = time.getNow()
             local success = xpcall(ptrToTestFunction, errorHandler, asserter)
@@ -264,3 +265,4 @@ function UnitTest:printFailures(failed)
         end
     end
 end
+


### PR DESCRIPTION
- Improve help text; same ordering, easier to update over time
- `test` command now accepts `--help` as first and only argument
- Assertion failures from the `Assert` class are treated like regular asserts. Detailed info still available via --verbose
- Leave extraneous `tests/` out from each test's output